### PR TITLE
Match the layout of ENetAddress in enet.h

### DIFF
--- a/Source/Managed/ENet.cs
+++ b/Source/Managed/ENet.cs
@@ -65,6 +65,7 @@ namespace ENet {
 		[MarshalAs(UnmanagedType.ByValArray, SizeConst = 16)]
 		public byte[] host;
 		public ushort port;
+		public ushort sin6_scope_id;
 	}
 
 	[StructLayout(LayoutKind.Sequential)]


### PR DESCRIPTION
The managed `ENetAddress` structure did not match the layout of the native
`ENetAddress` structure defined in enet.h.

The native structure has an additional field, so add that same field to
the corresponding managed structure.

Without this field in the managed structure, p/invoke calls into the
native code will marshal it with some arbitrary value in the native side
of the field, which can lead to unexpected problems. This happens with
Unity's IL2CPP, for example.

Fixes #13