### PR TITLE
Use PeerID instead of ConnectID, because ConnectID can be non-unique.

### DIFF
--- a/Source/Managed/ENet.cs
+++ b/Source/Managed/ENet.cs
@@ -607,6 +607,7 @@ namespace ENet {
 	public struct Peer {
 		private IntPtr nativePeer;
 		private uint nativeID;
+		private ushort nativePeerID;
 
 		internal IntPtr NativeData {
 			get {
@@ -621,6 +622,7 @@ namespace ENet {
 		public Peer(IntPtr peer) {
 			nativePeer = peer;
 			nativeID = nativePeer != IntPtr.Zero ? Native.enet_peer_get_id(nativePeer) : 0;
+			nativePeerID = nativePeer != IntPtr.Zero ? Native.enet_peer_get_peer_id(nativePeer) : 0;
 		}
 
 		public bool IsSet {
@@ -632,6 +634,12 @@ namespace ENet {
 		public uint ID {
 			get {
 				return nativeID;
+			}
+		}
+		
+		public ushort PeerID {
+			get {
+				return nativePeerID;
 			}
 		}
 
@@ -963,6 +971,9 @@ namespace ENet {
 
 		[DllImport(nativeLibrary, CallingConvention = CallingConvention.Cdecl)]
 		internal static extern uint enet_peer_get_id(IntPtr peer);
+		
+		[DllImport(nativeLibrary, CallingConvention = CallingConvention.Cdecl)]
+		internal static extern ushort enet_peer_get_peer_id(IntPtr peer);
 
 		[DllImport(nativeLibrary, CallingConvention = CallingConvention.Cdecl)]
 		internal static extern int enet_peer_get_ip(IntPtr peer, byte[] ip, IntPtr ipLength);

--- a/Source/Managed/ENet.cs
+++ b/Source/Managed/ENet.cs
@@ -607,7 +607,6 @@ namespace ENet {
 	public struct Peer {
 		private IntPtr nativePeer;
 		private uint nativeID;
-		private ushort nativePeerID;
 
 		internal IntPtr NativeData {
 			get {
@@ -622,7 +621,6 @@ namespace ENet {
 		public Peer(IntPtr peer) {
 			nativePeer = peer;
 			nativeID = nativePeer != IntPtr.Zero ? Native.enet_peer_get_id(nativePeer) : 0;
-			nativePeerID = nativePeer != IntPtr.Zero ? Native.enet_peer_get_peer_id(nativePeer) : 0;
 		}
 
 		public bool IsSet {
@@ -634,12 +632,6 @@ namespace ENet {
 		public uint ID {
 			get {
 				return nativeID;
-			}
-		}
-		
-		public ushort PeerID {
-			get {
-				return nativePeerID;
 			}
 		}
 
@@ -971,9 +963,6 @@ namespace ENet {
 
 		[DllImport(nativeLibrary, CallingConvention = CallingConvention.Cdecl)]
 		internal static extern uint enet_peer_get_id(IntPtr peer);
-		
-		[DllImport(nativeLibrary, CallingConvention = CallingConvention.Cdecl)]
-		internal static extern ushort enet_peer_get_peer_id(IntPtr peer);
 
 		[DllImport(nativeLibrary, CallingConvention = CallingConvention.Cdecl)]
 		internal static extern int enet_peer_get_ip(IntPtr peer, byte[] ip, IntPtr ipLength);

--- a/Source/Native/enet.h
+++ b/Source/Native/enet.h
@@ -4258,6 +4258,10 @@ extern "C" {
 	enet_uint32 enet_peer_get_id(const ENetPeer* peer) {
 		return peer->connectID;
 	}
+	
+	enet_uint16 enet_peer_get_peer_id(const ENetPeer* peer) {
+		return peer->incomingPeerID;
+	}
 
 	int enet_peer_get_ip(const ENetPeer* peer, char* ip, size_t ipLength) {
 		return enet_address_get_host_ip(&peer->address, ip, ipLength);

--- a/Source/Native/enet.h
+++ b/Source/Native/enet.h
@@ -4256,10 +4256,6 @@ extern "C" {
 	}
 
 	enet_uint32 enet_peer_get_id(const ENetPeer* peer) {
-		return peer->connectID;
-	}
-	
-	enet_uint16 enet_peer_get_peer_id(const ENetPeer* peer) {
 		return peer->incomingPeerID;
 	}
 


### PR DESCRIPTION
Use PeerID instead of ConnectID for the peer>ID, because ConnectID can be non-unique.
This will return the Index of the peer in the enet Peers array. values will be 0....4095
This index gets recycled. if you have clients connected and one gets dropped/disconnected and a new one connects the first unused index is re-used.