### PR TITLE
Fixed WSASend returning 1 instead of -1 on error.

### DIFF
--- a/Source/Native/enet.h
+++ b/Source/Native/enet.h
@@ -5000,7 +5000,7 @@ extern "C" {
 			}
 
 			if (WSASendTo(socket, (LPWSABUF)buffers, (DWORD)bufferCount, &sentLength, 0, address != NULL ? (struct sockaddr*)&sin : NULL, address != NULL ? sizeof(struct sockaddr_in6) : 0, NULL, NULL) == SOCKET_ERROR)
-				return (WSAGetLastError() == WSAEWOULDBLOCK) ? 0 : 1;
+				return (WSAGetLastError() == WSAEWOULDBLOCK) ? 0 : -1;
 
 			return (int)sentLength;
 		}


### PR DESCRIPTION
Fixed WSASend returning 1 instead of -1 on error.
Bug found by @c6burns