### PR TITLE
Return 0 instead of -1 on enet_protocol_receive_incoming_commands

### DIFF
--- a/Source/Native/enet.h
+++ b/Source/Native/enet.h
@@ -2494,7 +2494,7 @@ extern "C" {
 			}
 		}
 
-		return -1;
+		return 0;
 	}
 
 	static void enet_protocol_send_acknowledgements(ENetHost* host, ENetPeer* peer) {


### PR DESCRIPTION
Return 0 instead of -1 on enet_protocol_receive_incoming_commands when nothing received.
This allows the Service loop to continue running and not return an error.