### PR TITLE
Rtt variance

### DIFF
--- a/README.md
+++ b/README.md
@@ -347,7 +347,9 @@ Contains a managed pointer to the peer and cached ID.
 
 `Peer.State` returns a peer state described in the `PeerState` enumeration.
 
-`Peer.RoundTripTime` returns a round-trip time in milliseconds.
+`Peer.RoundTripTime` returns the mean round-trip time in milliseconds (using [Jacobson's alogrithm](https://www.netlab.tkk.fi/opetus/s383141/kalvot/E_tcp_flc.pdf)).
+
+`Peer.RoundTripTimeVariance` returns the round-trip time variance in milliseconds (using [Jacobson's alogrithm](https://www.netlab.tkk.fi/opetus/s383141/kalvot/E_tcp_flc.pdf)).
 
 `Peer.LastRoundTripTime` returns a round-trip time since the last acknowledgment in milliseconds.
 

--- a/Source/Managed/ENet.cs
+++ b/Source/Managed/ENet.cs
@@ -760,6 +760,14 @@ namespace ENet {
 			}
 		}
 
+		public uint RoundTripTimeVariance {
+			get {
+				ThrowIfNotCreated();
+
+				return Native.enet_peer_get_rtt_variance(nativePeer);
+			}
+		}
+
 		public uint LastRoundTripTime {
 			get {
 				ThrowIfNotCreated();
@@ -1131,6 +1139,9 @@ namespace ENet {
 
 		[DllImport(nativeLibrary, CallingConvention = CallingConvention.Cdecl)]
 		internal static extern uint enet_peer_get_rtt(IntPtr peer);
+
+		[DllImport(nativeLibrary, CallingConvention = CallingConvention.Cdecl)]
+		internal static extern uint enet_peer_get_rtt_variance(IntPtr peer);
 
 		[DllImport(nativeLibrary, CallingConvention = CallingConvention.Cdecl)]
 		internal static extern uint enet_peer_get_last_rtt(IntPtr peer);

--- a/Source/Native/enet.h
+++ b/Source/Native/enet.h
@@ -758,6 +758,7 @@ extern "C" {
 	ENET_API uint32_t enet_peer_get_mtu(const ENetPeer*);
 	ENET_API ENetPeerState enet_peer_get_state(const ENetPeer*);
 	ENET_API uint32_t enet_peer_get_rtt(const ENetPeer*);
+	ENET_API uint32_t enet_peer_get_rtt_variance(const ENetPeer*);
 	ENET_API uint32_t enet_peer_get_last_rtt(const ENetPeer* peer);
 	ENET_API uint32_t enet_peer_get_lastsendtime(const ENetPeer*);
 	ENET_API uint32_t enet_peer_get_lastreceivetime(const ENetPeer*);
@@ -5043,6 +5044,10 @@ extern "C" {
 
 	uint32_t enet_peer_get_rtt(const ENetPeer* peer) {
 		return peer->roundTripTime;
+	}
+
+	uint32_t enet_peer_get_rtt_variance(const ENetPeer* peer) {
+		return peer->roundTripTimeVariance;
 	}
 
 	uint32_t enet_peer_get_last_rtt(const ENetPeer* peer) {


### PR DESCRIPTION
* Add an interface for `peer->roundTripTimeVariance` to get information of the current RTT variance
* Add information to the documentation of how the RTT and its variance are calculated