### PR TITLE
Adding Apple silicon support for ENET Native library build

### DIFF
--- a/Source/Native/CMakeLists.txt
+++ b/Source/Native/CMakeLists.txt
@@ -31,6 +31,9 @@ if (ENET_STATIC)
 endif()
 
 if (ENET_SHARED)
+    if (APPLE)
+        SET(CMAKE_OSX_ARCHITECTURES "arm64;x86_64")
+    endif()
     add_definitions(-DENET_DLL)
     add_library(enet SHARED enet.c ${SOURCES})
 


### PR DESCRIPTION
Made changes to CMakeLists.txt so that dylib includes both x86_64 & arm64